### PR TITLE
Output path configuration option + linebreak bugfix

### DIFF
--- a/src/main/java/ch/tie/gradle/plugins/json2md/Json2mdConverterUtil.java
+++ b/src/main/java/ch/tie/gradle/plugins/json2md/Json2mdConverterUtil.java
@@ -1,13 +1,13 @@
 package ch.tie.gradle.plugins.json2md;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.StringUtils;
-
 import ch.tie.gradle.plugins.json2md.model.SpringConfigurationMetadata;
 import ch.tie.gradle.plugins.json2md.model.TableHeader;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class Json2mdConverterUtil {
 
@@ -76,5 +76,11 @@ public class Json2mdConverterUtil {
 
   private static String addSideBorders(String content) {
     return TABLE_DELIMITER_START + content + TABLE_DELIMITER;
+  }
+
+  public static String replaceLineBreaks(String line) {
+    return Optional.ofNullable(line)
+            .map(l -> l.replaceAll("\n", " "))
+            .orElse(null);
   }
 }

--- a/src/main/java/ch/tie/gradle/plugins/json2md/Json2mdTask.java
+++ b/src/main/java/ch/tie/gradle/plugins/json2md/Json2mdTask.java
@@ -26,6 +26,9 @@ public class Json2mdTask extends DefaultTask {
   @Input
   private List<String> excludedSources = new ArrayList<>();
 
+  @Inject
+  private String outputPath;
+
   @Input
   private String markdownFilename;
 
@@ -64,10 +67,19 @@ public class Json2mdTask extends DefaultTask {
     this.tableHeaders = tableHeaders;
   }
 
+  public String getOutputPath() {
+    return outputPath;
+  }
+
+  public void setOutputPath(String outputPath) {
+    this.outputPath = outputPath;
+  }
+
   @Inject
   public Json2mdTask(Project project, Json2mdReader json2mdReader, Json2mdWriter json2mdWriter) {
     this.project = project;
     this.markdownFilename = "ConfigurationProperties.md";
+    this.outputPath = project.getProjectDir().getPath();
     this.metadataPath =
         project.getLayout().getBuildDirectory().get().getAsFile().getPath() + "/classes/java/main/META-INF/spring-configuration-metadata.json";
     this.json2mdReader = json2mdReader;
@@ -80,6 +92,7 @@ public class Json2mdTask extends DefaultTask {
     springConfigurationMetadata.setTableHeaders(tableHeaders);
     springConfigurationMetadata.setExcludedSources(excludedSources);
     String markdown = Json2mdConverterUtil.metadata(springConfigurationMetadata, project.getName());
-    json2mdWriter.writeMarkdownFile(markdownFilename, markdown);
+    String output = String.join("/", outputPath, markdownFilename);
+    json2mdWriter.writeMarkdownFile(output, markdown);
   }
 }

--- a/src/main/java/ch/tie/gradle/plugins/json2md/model/Deprecation.java
+++ b/src/main/java/ch/tie/gradle/plugins/json2md/model/Deprecation.java
@@ -5,6 +5,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import ch.tie.gradle.plugins.json2md.Json2mdConverterUtil;
 
+import static ch.tie.gradle.plugins.json2md.Json2mdConverterUtil.replaceLineBreaks;
+
 public class Deprecation implements ToMarkdown {
 
   private String level = "";
@@ -20,7 +22,7 @@ public class Deprecation implements ToMarkdown {
   }
 
   public String getReason() {
-    return reason;
+    return replaceLineBreaks(reason);
   }
 
   public void setReason(String reason) {

--- a/src/main/java/ch/tie/gradle/plugins/json2md/model/Property.java
+++ b/src/main/java/ch/tie/gradle/plugins/json2md/model/Property.java
@@ -6,6 +6,8 @@ import java.util.function.Supplier;
 
 import ch.tie.gradle.plugins.json2md.Json2mdConverterUtil;
 
+import static ch.tie.gradle.plugins.json2md.Json2mdConverterUtil.replaceLineBreaks;
+
 public class Property implements ToMarkdown {
 
   // @formatter:off
@@ -44,7 +46,7 @@ public class Property implements ToMarkdown {
   }
 
   public String getDescription() {
-    return description;
+    return replaceLineBreaks(description);
   }
 
   public void setDescription(String description) {


### PR DESCRIPTION
Hey! We've found your plugin useful for our needs. However, there are couple of issues with it. First of all, it doesn't handle line breaks while generating md table. It means that property description javadocs having line breaks will mess output table up. We've also needed an opportunity to specify output file location since the default doesn't suit us. This PR solves these issues 